### PR TITLE
127 reparar funcionamiento de status de evidencias

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -23,7 +23,7 @@ class UserController extends Controller
                 });
             });
         }*/
-        
+
         return response()->json([
             'usuarios' => $query->get(),
             'roles' => ['DIRECTIVO', 'JEFE DE AREA', 'COORDINADOR DE CARRERA', 'PROFESOR RESPONSABLE', 'PROFESOR', 'DEPARTAMENTO UNIVERSITARIO', 'PERSONAL DE APOYO', 'ADMINISTRADOR']
@@ -62,7 +62,7 @@ class UserController extends Controller
         $assignments = Evidence::with([
             'standard:standard_id,standard_name', // Traemos el criterio (nombre del standard)
             'status' => function ($query) {
-                $query->orderByDesc('status_date')->limit(1); // Solo el último estado
+                $query->orderByDesc('status_date'); // Solo el último estado
             }
         ])
             ->where('user_rpe', $user->user_rpe)
@@ -72,7 +72,7 @@ class UserController extends Controller
                 return [
                     'evidence_id' => $evidence->evidence_id,
                     'criterio' => $evidence->standard?->standard_name,
-                    'estado' => $evidence->status->first()?->status_description ?? 'PENDIENTE', // El nombre del estado más reciente
+                    'estado' => $evidence->status->first()?->status_description ?? 'MALO', // El nombre del estado más reciente
                 ];
             });
 


### PR DESCRIPTION
El error era que solo agarraba el estado de la primera asignación que encontraba, se corrigió "UserController.php", eliminando la restricción de solo tomar el primer estado que encuentra. Esto se comparó con "EvidenceController.php"

Para más información del problema que se resolvió:

- En el cuadro para seleccionar las asignaciones, estaba incorrecto, solo estaba bien la primera asignación y las demás mostraban "PENDIENTE", esto debido a que es el valor por defecto que manda el _fetch_ en Backend, especificamente 
- En el cuadro de información de revisor si mostraba la información correcta, en base a esto se corrigió el anterior punto