### PR TITLE
Reparacion de la vista de Cvs como administrador

### DIFF
--- a/app/Http/Controllers/AccreditationProcessController.php
+++ b/app/Http/Controllers/AccreditationProcessController.php
@@ -283,4 +283,61 @@ class AccreditationProcessController extends Controller
 
         return $users_area;
     }
+
+    public function findProcessById($processId)
+    {
+        $process = DB::select("
+            SELECT 
+                ap.process_id,
+                ap.process_name,
+                ap.start_date,
+                ap.end_date,
+                ap.due_date,
+                ap.finished,
+                
+                c.career_name,
+                c.career_id,
+                u_career.user_name AS career_owner,
+                u_career.user_rpe AS career_owner_rpe,
+                
+                a.area_name,
+                a.area_id,
+                u_area.user_name AS area_owner,
+                u_area.user_rpe AS area_owner_rpe,
+                
+                fr.frame_name,
+                ap.frame_id
+                
+            FROM accreditation_processes ap
+            
+            JOIN careers c
+            ON ap.career_id = c.career_id
+            JOIN users u_career
+            ON c.user_rpe = u_career.user_rpe
+            
+            JOIN areas a
+            ON c.area_id = a.area_id
+            JOIN users u_area
+            ON a.user_rpe = u_area.user_rpe
+            
+            LEFT JOIN frames_of_reference fr
+            ON ap.frame_id = fr.frame_id
+            
+            WHERE ap.process_id = ?
+        ", [$processId]);
+
+        if (empty($process)) {
+            return response()->json([
+                'message' => 'Proceso no encontrado.',
+                'process_id' => $processId,
+                'success' => false
+            ], 404);
+        }
+
+        return response()->json([
+            'data' => $process[0],
+            'success' => true,
+            'message' => 'Proceso encontrado exitosamente.'
+        ]);
+    }
 }

--- a/app/Http/Controllers/CvController.php
+++ b/app/Http/Controllers/CvController.php
@@ -30,7 +30,7 @@ class CvController extends Controller
             return response()->json(['error' => 'Usuario no encontrado'], 404);
         }
         
-        if($currentUser->user_rpe != $user->user_rpe && !in_array($user->user_role, ['ADMINISTRADOR', 'JEFE DE AREA', 'COORDINADOR', 'DIRECTIVO'])){
+        if($currentUser->user_rpe != $user->user_rpe && !in_array($currentUser->user_role, ['ADMINISTRADOR', 'JEFE DE AREA', 'COORDINADOR DE CARRERA', 'DIRECTIVO'])){
             return response()->json(['error' => 'No se puede acceder a este CV'], 403);
         }
         $cv = Cv::where('cv_id', $user->cv_id)->first();

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -14,7 +14,7 @@ class CheckRole
      */
     private const VALID_ROLES = [
         'ADMINISTRADOR',
-        'COORDINADOR',
+        'COORDINADOR DE CARRERA',
         'JEFE DE AREA',
         'PROFESOR',
         'DIRECTIVO',

--- a/database/sql/datos prueba.sql
+++ b/database/sql/datos prueba.sql
@@ -499,10 +499,10 @@ VALUES (1, 1, 'Criterio de seguridad', 'Descripción del estándar 1', FALSE, 'A
 
 
 -- Insertar en la tabla evidences
-INSERT INTO evidences (evidence_id, standard_id, user_rpe, group_id, process_id, due_date)
-VALUES (1, 1, '10285', 1, 1, '2025-05-01'),
- (2, 1, '10285', 1, 1, '2025-05-01'),
- (3, 1, '10285', 1, 1, '2025-05-01');
+INSERT INTO evidences (evidence_id, standard_id, user_rpe, process_id, due_date)
+VALUES (1, 1, '10285', 1, '2025-05-01'),
+ (2, 1, '10285', 1, '2025-05-01'),
+ (3, 1, '10285', 1, '2025-05-01');
 
 
 -- Insertar en la tabla revisers

--- a/routes/api.php
+++ b/routes/api.php
@@ -66,6 +66,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::get('/linked_processes', [ProcessController::class, 'linkedProcesses']);
     Route::post('/test_check_user_example', [ProcessController::class, 'checkUser']);
     Route::get('/processes/{processId}', [AccreditationProcessController::class, 'getProcessById']);
+    Route::get('/processes/{processId}/find', [AccreditationProcessController::class, 'findProcessById']);
 });
 
 //1. Login
@@ -95,7 +96,7 @@ Route::middleware('auth:sanctum')->get('/menuPrinicipal', function (Request $req
 //3. Confitguracion personal
 Route::middleware([
     'auth:sanctum',
-    'role:ADMINISTRADOR, JEFE DE AREA, COORDINADOR, PROFESOR, PERSONAL DE APOYO, DIRECTIVO'
+    'role:ADMINISTRADOR, JEFE DE AREA, COORDINADOR DE CARRERA, PROFESOR, PERSONAL DE APOYO, DIRECTIVO'
 ])->get('/personalInfo', function () {
     return response()->json(['message' => 'Informacion personal']);
 });
@@ -111,7 +112,7 @@ Route::middleware(['auth:sanctum'])->get('/evidences/by-standard/{standard_id}',
 //REPETIDA CON CV
 Route::middleware([
     'auth:sanctum',
-    'role:ADMINISTRADOR, JEFE DE AREA, COORDINADOR, PROFESOR, DIRECTIVO, DEPARTAMENTO UNIVERSITARIO, PERSONAL DE APOYO'
+    'role:ADMINISTRADOR, JEFE DE AREA, COORDINADOR DE CARRERA, PROFESOR, DIRECTIVO, DEPARTAMENTO UNIVERSITARIO, PERSONAL DE APOYO'
 ])->get('/cv', function () {
     return response()->json(['message' => 'Subir evidencia']);
 });
@@ -119,7 +120,7 @@ Route::middleware([
 //5. Revisar evidencias
 Route::middleware([
     'auth:sanctum',
-    'role:ADMINISTRADOR,JEFE DE AREA,COORDINADOR,DIRECTIVO'
+    'role:ADMINISTRADOR,JEFE DE AREA,COORDINADOR DE CARRERA,DIRECTIVO'
 ])->get('/ReviewEvidence', [EvidenceController::class, 'allEvidence']);
 
 // 5.a. Revisar archivos
@@ -152,7 +153,7 @@ Route::middleware(['auth:sanctum'])->get('/Dashboard', function () {
 // 8.Gestion Evidencias
 Route::middleware([
     'auth:sanctum',
-    'role:ADMINISTRADOR, JEFE DE AREA, COORDINADOR'
+    'role:ADMINISTRADOR, JEFE DE AREA, COORDINADOR DE CARRERA'
 ])->get('/GestionEvidencias', function () {
     return response()->json(['message' => 'Gestionar evidencias']);
 });
@@ -283,7 +284,7 @@ Route::get('/mensaje', function () {
     return response()->json(['mensaje' => '¡Hola desde Laravel!']);
 });
 //Rutas hechas en la rama de asignarTareas
-Route::middleware(['auth:sanctum', 'role:ADMINISTRADOR,COORDINADOR,JEFE DE AREA,DIRECTIVO,CAPTURISTA'])->group(function () {
+Route::middleware(['auth:sanctum', 'role:ADMINISTRADOR,COORDINADOR DE CARRERA,JEFE DE AREA,DIRECTIVO,CAPTURISTA'])->group(function () {
     Route::get('/revisers', [ReviserController::class, 'index']);
     Route::post('/reviser', [ReviserController::class, 'store']);
     Route::post('/evidence', [EvidenceController::class, 'store']);


### PR DESCRIPTION
En el controlador de Backend la función index tenia un condicional que no permitia acceso si el usuario dueño del cv no era igual al usuario que buscaba acceder y si no tenia los roles de ADMINISTRADOR, JEFE DE AREA, COORDINADOR o DIRECTIVO no podia acceder.

El condicional estaba mal escrito, comparaba con el rol del usuario dueño del cv no del usuario que accedia, cambie eso y tambien cambie el nombre de coordinador a coordinador de carrera 